### PR TITLE
Comment out sequelize.sync in server.js

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -145,7 +145,7 @@ io.on("connection", (socket) => {
 const startServer = async () => {
     try {
         await connectToDatabase();
-        await sequelize.sync({ alter: true }); 
+        // await sequelize.sync({ alter: true }); 
         console.log("Database connected successfully.");
         createSuperAdminIfNotExists()
         server.listen(port, () => {


### PR DESCRIPTION
Commented out the sequelize.sync call to prevent altering the database schema on startup.